### PR TITLE
Rebuild to remove python dependency

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: "a34508b7ca862c3c07d2b4dafbaeb39cca7e33f8890195f3dfdc8d397a6da18b"
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not linux]
 
 requirements:
@@ -23,9 +23,7 @@ requirements:
   host:
     - cppzmq
     - cpptango
-  run:
-    # cpptango set in run_exports
-    - {{ pin_compatible('omniorb', max_pin='x.x') }}
+    - omniorb
 
 test:
   commands:


### PR DESCRIPTION
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

omniorb should have been part of the host dependencies.
The run_exports will automatically add omniorb-libs as run dependency.
This removes Python as dependency