### PR TITLE
Fix windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,16 +74,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `tango-test` can be installed with:
+Once the `conda-forge` channel has been enabled, `tango-test` can be installed with `conda`:
 
 ```
 conda install tango-test
 ```
 
-It is possible to list all of the versions of `tango-test` available on your platform with:
+or with `mamba`:
+
+```
+mamba install tango-test
+```
+
+It is possible to list all of the versions of `tango-test` available on your platform with `conda`:
 
 ```
 conda search tango-test --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search tango-test --channel conda-forge
+```
+
+Alternatively, `mamba repoquery` may provide more information:
+
+```
+# Search all versions available on your platform:
+mamba repoquery search tango-test --channel conda-forge
+
+# List packages depending on `tango-test`:
+mamba repoquery whoneeds tango-test --channel conda-forge
+
+# List dependencies of `tango-test`:
+mamba repoquery depends tango-test --channel conda-forge
 ```
 
 
@@ -101,10 +126,12 @@ for each of the installable packages. Such a repository is known as a *feedstock
 A feedstock is made up of a conda recipe (the instructions on what and how to build
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
-[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
-packages to the [conda-forge](https://anaconda.org/conda-forge)
-[Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
+[Azure](https://azure.microsoft.com/en-us/services/devops/), [GitHub](https://github.com/),
+[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
+[Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
+it is possible to build and upload installable packages to the
+[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
+channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -11,7 +11,7 @@ cmake -G "NMake Makefiles" ^
       -DCMAKE_PREFIX_PATH:PATH="%LIBRARY_PREFIX%" ^
       -DTANGO_PKG_LIBRARY_DIRS:PATH="%LIBRARY_LIB%" ^
       -DTANGO_PKG_INCLUDE_DIRS:PATH="%LIBRARY_INC%" ^
-      -DTANGO_PKG_LIBRARIES="tango;omniORB4_rt;omniDynamic4_rt;COS4_rt;omnithread_rt;libzmq-mt-s-4_3_4;comctl32;wsock32;Ws2_32" ^
+      -DTANGO_PKG_LIBRARIES="tango;omniORB4_rt;omniDynamic4_rt;COS4_rt;omnithread_rt;libzmq-mt-4_3_4;comctl32;wsock32;Ws2_32" ^
       ..
 if errorlevel 1 exit 1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,11 @@ package:
 source:
   url: https://gitlab.com/tango-controls/TangoTest/-/archive/{{ version }}/TangoTest-{{ version }}.tar.gz
   sha256: f335e9e3d672c2bc160f3d927eade46a37ba51650b8e5501cb12d15b9edd433a
+  patches:
+    - tango-include-dirs.patch  # [win]
 
 build:
-  number: 1
+  number: 2
   skip: true  # [osx]
 
 requirements:

--- a/recipe/tango-include-dirs.patch
+++ b/recipe/tango-include-dirs.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5f96806..f36f348 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -26,7 +26,7 @@ set(HEADERS
+ link_directories(${TANGO_PKG_LIBRARY_DIRS})
+ 
+ add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS})
+-target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${TANGO_PKG_INCLUDE_DIRS})
++target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${TANGO_PKG_INCLUDE_DIRS} ${TANGO_PKG_INCLUDE_DIRS}/tango)
+ target_compile_options(${PROJECT_NAME} PUBLIC ${TANGO_PKG_CFLAGS_OTHER})
+ target_link_libraries(${PROJECT_NAME} PUBLIC ${TANGO_PKG_LIBRARIES})
+ install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin)


### PR DESCRIPTION
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

Fix windows build:

- Fix incorrect libzmq (libzmq-mt-s-4_3_4 is for static - remove `-s`)
- Fix tango include dir due to new cppTango build (linked to https://gitlab.com/tango-controls/cppTango/-/merge_requests/924)

